### PR TITLE
Prevent typing indicator from shaking the chat

### DIFF
--- a/src/chat/components/middle/MessageList.js
+++ b/src/chat/components/middle/MessageList.js
@@ -71,9 +71,10 @@ class MessageList extends React.Component {
                         key={message._id}
                     />
                 ))}
-                {this.props.chat.isTyping && (
-                    <TypingIndicator key="typing-thing" />
-                )}
+                <TypingIndicator
+                    key="typing-thing"
+                    isVisible={this.props.chat.isTyping}
+                />
             </div>
         )
     }

--- a/src/chat/components/middle/MessageList.js
+++ b/src/chat/components/middle/MessageList.js
@@ -74,6 +74,7 @@ class MessageList extends React.Component {
                 <TypingIndicator
                     key="typing-thing"
                     isVisible={this.props.chat.isTyping}
+                    wasVisible={this.props.chat.wasTyping}
                 />
             </div>
         )

--- a/src/chat/components/middle/TypingIndicator.js
+++ b/src/chat/components/middle/TypingIndicator.js
@@ -6,9 +6,16 @@ import { chatItem as styles } from "~/chat/styles/middle";
 @Radium
 export default class TypingIndicator extends React.Component {
 
+    static propTypes = {
+        isVisible: React.PropTypes.bool,
+    }
+
     render() {
         return (
-            <div style={styles.bubbleWrapper}>
+            <div style={[
+                styles.bubbleWrapper,
+                this.props.isVisible ? {} : { visibility: "hidden" },
+            ]}>
                 <div style={styles.otherBubble}>
                     ...
                 </div>

--- a/src/chat/components/middle/TypingIndicator.js
+++ b/src/chat/components/middle/TypingIndicator.js
@@ -8,9 +8,13 @@ export default class TypingIndicator extends React.Component {
 
     static propTypes = {
         isVisible: React.PropTypes.bool,
+        wasVisible: React.PropTypes.bool,
     }
 
     render() {
+        if (!this.props.isVisible && !this.props.wasVisible) {
+            return null;
+        }
         return (
             <div style={[
                 styles.bubbleWrapper,

--- a/src/chat/reducers.js
+++ b/src/chat/reducers.js
@@ -28,6 +28,12 @@ function chats(state = initialChats, action) {
                     messages: {
                         $push: [action.message],
                     },
+                    isTyping: {
+                        $set: false,
+                    },
+                    wasTyping: {
+                        $set: false,
+                    },
                 },
             })
         case "SEND_MESSAGE_LOADING":
@@ -84,6 +90,9 @@ function chats(state = initialChats, action) {
                 [index]: {
                     isTyping: {
                         $set: action.isTyping,
+                    },
+                    wasTyping: {
+                        $set: state[index].isTyping,
                     },
                 },
             })


### PR DESCRIPTION
Now, if the typing indicator appears once, the space it occupied will remain, even if someone stops typing, until there is another message. Fixes #29.