### PR TITLE
Refactor hide leftbar

### DIFF
--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -57,3 +57,15 @@ export function toggleLeftbar() {
     }
 }
 
+export function openLeftbar() {
+    return {
+        type: "OPEN_LEFTBAR"
+    }
+}
+
+export function closeLeftbar() {
+    return {
+        type: "CLOSE_LEFTBAR"
+    }
+}
+

--- a/src/shared/actions.js
+++ b/src/shared/actions.js
@@ -51,14 +51,9 @@ export const receiveMessage = ({ chatId, message, type, name }) => (dispatch) =>
     }
 }
 
-export function openLeftbar() {
+export function toggleLeftbar() {
     return {
-        type: "OPEN_LEFTBAR",
+        type: "TOGGLE_LEFTBAR",
     }
 }
 
-export function closeLeftbar() {
-    return {
-        type: "CLOSE_LEFTBAR",
-    }
-}

--- a/src/shared/components/leftbar.js
+++ b/src/shared/components/leftbar.js
@@ -19,7 +19,9 @@ export const LeftbarContainer = Radium((props) => {
             <RadiumGlyphicon
                 glyph={props.isOpen ? "chevron-left" : "chevron-right"}
                 onClick={props.onToggle}
-                style={[styles.hideButton, { left: props.isOpen ? "270px" : "10px" }]}
+                style={[styles.hideLeftbar.button, {
+                    left: props.isOpen ? styles.hideLeftbar.left.open : styles.hideLeftbar.left.closed
+                }]}
             />
         </div>
     )

--- a/src/shared/reducers.js
+++ b/src/shared/reducers.js
@@ -13,10 +13,8 @@ function onlineClients(state = [], action) {
 
 function isLeftbarOpen(state = true, action) {
     switch (action.type) {
-        case "OPEN_LEFTBAR":
-            return true;
-        case "CLOSE_LEFTBAR":
-            return false;
+        case "TOGGLE_LEFTBAR":
+            return !state;
         default:
             return state;
     }

--- a/src/shared/reducers.js
+++ b/src/shared/reducers.js
@@ -15,6 +15,10 @@ function isLeftbarOpen(state = true, action) {
     switch (action.type) {
         case "TOGGLE_LEFTBAR":
             return !state;
+        case "OPEN_LEFTBAR":
+            return true;
+        case "CLOSE_LEFTBAR":
+            return false;
         default:
             return state;
     }

--- a/src/shared/styles/leftbar.js
+++ b/src/shared/styles/leftbar.js
@@ -1,6 +1,8 @@
 // shared by calendar, chat, and drive
 import { defaultColor, hoverColor, selectedColor } from "~/shared/styles/colors";
 
+const leftbarWidth = 260;
+
 const item = {
     height: "60px",
     borderBottom: "1px solid black",
@@ -13,7 +15,7 @@ const item = {
 export default {
     div: {
         backgroundColor: defaultColor,
-        width: "260px",
+        width: leftbarWidth + "px",
         height: "calc(100% - 30px)",
         position: "fixed",
         top: "40px",
@@ -41,19 +43,25 @@ export default {
     glyph: {
         marginRight: "5px",
     },
-    hideButton: {
-        position: "fixed",
-        top: "calc(100% - 40px)",
-        backgroundColor: selectedColor,
-        width: "28px",
-        height: "30px",
-        padding: "7px",
-        cursor: "pointer",
-        zIndex: "91",
-        borderRadius: "20px",
-        boxShadow: "0px 2px 8px -4px black",
-        ":hover": {
-            backgroundColor: "darkOrange"
+    hideLeftbar: {
+        button: {
+            position: "fixed",
+            top: "calc(100% - 40px)",
+            backgroundColor: selectedColor,
+            width: "28px",
+            height: "30px",
+            padding: "7px",
+            cursor: "pointer",
+            zIndex: "91",
+            borderRadius: "20px",
+            boxShadow: "0px 2px 8px -4px black",
+            ":hover": {
+                backgroundColor: "darkOrange"
+            }
+        },
+        left: {
+            open: leftbarWidth + 10 + "px",
+            closed: "10px",
         }
     }
 }

--- a/src/util/leftbar.js
+++ b/src/util/leftbar.js
@@ -1,13 +1,9 @@
 import React from "react";
-import { openLeftbar, closeLeftbar } from "~/shared/actions";
+import { toggleLeftbar } from "~/shared/actions";
 
 function onToggle(self, str) {
     self.setState({ [str]: !self.state[str] });
-    if (self.state[str]) {
-        self.props.dispatch(closeLeftbar());
-    } else {
-        self.props.dispatch(openLeftbar());
-    }
+    self.props.dispatch(toggleLeftbar());
 }
 
 export const leftbarProps = (self, str) => {


### PR DESCRIPTION
Slight refactoring to hide leftbar. I had two actions for hide leftbar when I could've just used one, so I felt it necessary to fix that. In addition, the "left" style of hide leftbar was moved to the styles file where it should be.