### PR TITLE
Fix folder sorting

### DIFF
--- a/src/drive/actions.js
+++ b/src/drive/actions.js
@@ -3,12 +3,17 @@ import { request } from "~/util/ajax";
 const fetchFolders = () => async (dispatch, getStore) => {
     const store = getStore();
     const { data } = await request("GET", "/folders");
+    const defaultFolders = data.filter(folder => folder.defaultFolder);
+    const sortedFolders = [
+        defaultFolders.find(folder => folder.name === "Team Files"),
+        defaultFolders.find(folder => folder.name === "Personal Files")
+    ].concat(data.filter(f => defaultFolders.indexOf(f) === -1));
     dispatch({
         type: "SET_FOLDERS",
-        folders: data,
+        folders: sortedFolders,
     });
     if (!store.selectedFolder && data.length !== 0) {
-        dispatch(setFolder(data[0]))
+        dispatch(setFolder(sortedFolders[0]))
     }
 }
 

--- a/src/drive/components/Leftbar.js
+++ b/src/drive/components/Leftbar.js
@@ -26,15 +26,6 @@ class Leftbar extends React.Component {
         await this.props.dispatch(setFolder(folder));
     }
 
-    sortedFolders = () => {
-        const folders = this.props.folders;
-        if (folders.length === 0) {
-            return [];
-        }
-        const special = [ folders.find(folder => folder.defaultFolder) ];
-        return special.concat(folders.filter(f => special.indexOf(f) === -1));
-    }
-
     render() {
         return (
             <LeftbarContainer { ...leftbarProps(this, "isLeftbarOpen") }>
@@ -50,7 +41,7 @@ class Leftbar extends React.Component {
                     New Folder
                 </LeftbarButton>
 
-                {this.sortedFolders().map(folder => (
+                {this.props.folders.map(folder => (
                     <LeftbarButton
                         isSelected={folder === this.props.selectedFolder}
                         key={folder._id}


### PR DESCRIPTION
Puts default folders at the top with Team Files first and Personal Files second. Moves this state of sorted folders to redux store rather than just in view. Also ensures that the initially selected folder is the first folder. Solves #46