### PR TITLE
Remove "g" flag from audience select search regex

### DIFF
--- a/src/shared/components/audience/AudienceSelect.js
+++ b/src/shared/components/audience/AudienceSelect.js
@@ -104,7 +104,7 @@ export default class AudienceSelect extends React.Component {
                 shownUsers: this.state.allUsers,
             }
         } else {
-            const regex = new RegExp(this.state.query.trim().replace(/\s+/g, "|"), "ig");
+            const regex = new RegExp(this.state.query.trim().replace(/\s+/g, "|"), "i");
             return {
                 shownUsers: this.state.allUsers.filter(user => (
                     regex.test(user.firstname) || regex.test(user.lastname)


### PR DESCRIPTION
When 2 members of the audience in a row have the same first name, the
"g" flag causes the second one not to be matched.