### PR TITLE
Add content label to modal

### DIFF
--- a/src/shared/components/DimModal.js
+++ b/src/shared/components/DimModal.js
@@ -24,6 +24,7 @@ export default class DimModal extends React.Component {
         return (
             <Modal
                 { ...this.props }
+                contentLabel = "Modal"
                 style={{ overlay: overlayStyle, content: this.props.style }}
             >
                 {this.props.children}


### PR DESCRIPTION
Removes annoying warning about required contentLabel being undefined in modal.